### PR TITLE
make type definitions work with current version of TypeScript (3.5.3)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,4 +21,6 @@ declare module 'sqlite3-helper' {
     }
 }
 
+import { DBOptions, DBInstance } from 'sqlite3-helper'
+
 export default function DB(options?: DBOptions): DBInstance

--- a/no-generators.d.ts
+++ b/no-generators.d.ts
@@ -1,6 +1,6 @@
-declare module 'sqlite3-helper' {
+import sqlite3 from 'sqlite3'
 
-    import sqlite3 = require('sqlite3')
+declare module 'sqlite3-helper' {
 
     type MigrationOptions = {
         /** Whether to set to 'last' to automatically reapply the last migration-file. Default: false */
@@ -256,5 +256,7 @@ declare module 'sqlite3-helper' {
     }
 
 }
+
+import { DBOptions, DBInstance } from 'sqlite3-helper'
 
 export default function DB(options?: DBOptions): DBInstance


### PR DESCRIPTION
I updated the type definitions so they work with current version of TypeScript (3.5.3).