### PR TITLE
Various fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,26 +1,26 @@
-import './no-generators'
+import * as noGenerators from './no-generators'
 
-declare module 'sqlite3-helper' {
+export type MigrationOptions = noGenerators.MigrationOptions
+export type DBOptions = noGenerators.DBOptions
+export type DataObject = noGenerators.DataObject
+export type WhereClause = noGenerators.WhereClause
 
-    interface DBInstance {
+export interface DBInstance extends noGenerators.DBInstance {
 
-        /**
-         * Similar to .query(), but instead of returning every row together, an iterator is returned so you can retrieve the rows one by one.
-         * @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#iteratebindparameters---iterator
-         *
-         * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
-         * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
-         * @returns {Iterator}
-         */
-        queryIterate<RowData = DataObject>(query: string, ...bindParameters: any[]): Iterable<RowData>
+    /**
+     * Similar to .query(), but instead of returning every row together, an iterator is returned so you can retrieve the rows one by one.
+     * @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#iteratebindparameters---iterator
+     *
+     * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
+     * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
+     * @returns {Iterator}
+     */
+    queryIterate<RowData = DataObject>(query: string, ...bindParameters: any[]): Iterable<RowData>
 
-    }
-
-    interface Statement {
-        iterate<RowData = DataObject>(...bindParameters: any[]): Iterable<RowData>
-    }
 }
 
-import { DBOptions, DBInstance } from 'sqlite3-helper'
+export interface Statement extends noGenerators.Statement {
+    iterate<RowData = DataObject>(...bindParameters: any[]): Iterable<RowData>
+}
 
 export default function DB(options?: DBOptions): DBInstance

--- a/no-generators.d.ts
+++ b/no-generators.d.ts
@@ -1,262 +1,256 @@
 import sqlite3 from 'sqlite3'
 
-declare module 'sqlite3-helper' {
-
-    type MigrationOptions = {
-        /** Whether to set to 'last' to automatically reapply the last migration-file. Default: false */
-        force?: 'last' | false
-        /** The name of the database table that is used to keep track. Default: 'migration' */
-        table?: string
-        /** The path of the migration files. Default: './migrations' */
-        migrationsPath?: string
-    }
-
-    type DBOptions = {
-        /** Path to sqlite database file. Default: './data/sqlite3.db' */
-        path?: string
-        /** Whether to create a db only in memory. Default: false */
-        memory?: boolean
-        /** Whether to open database readonly. Default: false */
-        readonly?: boolean
-        /** Whether to throw error if database not exists. Default: false */
-        fileMustExist?: boolean
-        /** Whether to automatically enable 'PRAGMA journal_mode = WAL'. Default: true */
-        WAL?: boolean
-        /** Migration options. Disable completely by setting `migrate: false` */
-        migrate?: MigrationOptions | false
-    }
-
-    type DataObject = { [key:string]: any }
-
-    /**
-     * Specifies a where clause.
-     * 
-     *   - Either a string containing the value to use as ID that will be translated to ['id = ?', id]
-     *   - Or an array with a string and the replacements for ? after that. F.e. ['id > ? && name = ?', id, name].
-     *   - Or an object with key values. F.e. {id: params.id}. Or simply an ID that will be translated to ['id = ?', id]
-     */
-    type WhereClause = string | any[] | DataObject
-
-    interface DBInstance {
-        connection(): Promise<sqlite3.Database>
-
-        prepare(sql: string, ...params: any[]): Promise<Statement>
-
-        exec(sql: string): Promise<void>
-
-        //DB.prototype.pragma = function (source, simplify = false) {
-
-        //DB.prototype.checkpoint = function (databaseName) {
-
-        //DB.prototype.register = function (...args) {
-
-        close(): Promise<void>
-
-        //DB.prototype.defaultSafeIntegers = function (toggleState) {
-
-        /**
-         * Executes the prepared statement. When execution completes it returns an info object describing any changes made. The info object has two properties:
-         *
-         * info.changes: The total number of rows that were inserted, updated, or deleted by this operation. Changes made by foreign key actions or trigger programs do not count.
-         * info.lastInsertROWID: The rowid of the last row inserted into the database (ignoring those caused by trigger programs). If the current statement did not insert any rows into the database, this number should be completely ignored.
-         *
-         * If execution of the statement fails, an Error is thrown.
-         * @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#runbindparameters---object
-         *
-         * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
-         * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
-         * @returns {object}
-         */
-        run(query: string, ...bindParameters: any[]): Promise<sqlite3.RunResult>
-
-        /**
-         * Returns all values of a query
-         * @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#allbindparameters---array-of-rows
-         *
-         * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
-         * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
-         * @returns {array}
-         */
-        query<RowData = DataObject>(query: string, ...bindParameters: any[]): Promise<RowData[]>
-
-        /**
-         * Similar to .query(), but instead of returning every row together, an iterator is returned so you can retrieve the rows one by one.
-         * @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#iteratebindparameters---iterator
-         *
-         * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
-         * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
-         * @returns {Iterator}
-         */
-        queryIterate<RowData = DataObject>(query: string, ...bindParameters: any[]): Iterable<RowData>
-
-        /**
-         * Returns the values of the first row of the query-result
-         * @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#getbindparameters---row
-         *
-         * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
-         * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
-         * @returns {Object|null}
-         */
-        queryFirstRow<RowData = DataObject>(query: string, ...bindParameters: any[]): Promise<RowData|null>
-
-        /**
-         * Returns the values of the first row of the query-result
-         * @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#getbindparameters---row
-         * It returns always an object and thus can be used with destructuring assignment
-         *
-         * @example const {id, name} = DB().queryFirstRowObject(sql)
-         * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
-         * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
-         * @returns {Object}
-         */
-        queryFirstRowObject<RowData = DataObject>(query: string, ...bindParameters: any[]): Promise<RowData|{}>
-
-        /**
-         * Returns the value of the first column in the first row of the query-result
-         *
-         * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
-         * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
-         * @returns {any}
-         */
-        queryFirstCell<CellType = any>(query: string, ...bindParameters: any[]): Promise<CellType|undefined>
-
-        /**
-         * Calls a callback for every row
-         *
-         * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
-         * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
-         * @param {any} callback the callback that is called
-         * @returns {integer} count
-         */
-        each<RowData = DataObject>(query: string, p1: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(query: string, p1: any, p2: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, p5: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, p8: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, p8: any, p9: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, p8: any, p9: any, p10: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(query: string, ...bindParameters: any[]): Promise<number>
-
-        /**
-         * Returns an Array that only contains the values of the specified column
-         *
-         * @param {Object} column Name of the column
-         * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
-         * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
-         * @returns {array}
-         */
-        queryColumn<ColumnType = any>(column: string, query: string, ...bindParameters: any[]): Promise<ColumnType[]>
-
-        /**
-         * Returns a Object that get it key-value-combination from the result of the query
-         *
-         * @param {String} key Name of the column that values should be the key
-         * @param {Object} column Name of the column that values should be the value for the object
-         * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
-         * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
-         * @returns {object}
-         */
-        queryKeyAndColumn<ValueColumnType = any>(key: string, column: string, query: string, ...bindParameters: any[]): Promise<{[key:string]: ValueColumnType}>
-
-        /**
-         * Create an update statement; create more complex one with exec yourself.
-         *
-         * @param {String} table Name of the table
-         * @param {Object} data a Object of data to set. Key is the name of the column. Value 'undefined' is filtered
-         * @param {String|Array|Object} where required. array with a string and the replacements for ? after that. F.e. ['id > ? && name = ?', id, name]. Or an object with key values. F.e. {id: params.id}. Or simply an ID that will be translated to ['id = ?', id]
-         * @param {undefined|Array} whiteList optional List of columns that can only be updated with "data"
-         * @returns {Integer} The number of updated rows
-         */
-        update<RowData = DataObject>(table: string, data: Partial<RowData>, where: WhereClause, whiteList?: string[]): Promise<number>
-
-        /**
-         * Create an update statement; create more complex one with exec yourself.
-         *
-         * @param {String} table Name of the table
-         * @param {Object} data a Object of data to set. Key is the name of the column. Value 'undefined' is filtered
-         * @param {String|Array|Object} where required. array with a string and the replacements for ? after that. F.e. ['id > ? && name = ?', id, name]. Or an object with key values. F.e. {id: params.id}. Or simply an ID that will be translated to ['id = ?', id]
-         * @param {undefined|Array} whiteBlackList optional List of columns that can not be updated with "data" (blacklist)
-         * @returns {Integer} The number of updated rows
-         */
-        updateWithBlackList(table: string, data: DataObject, where: WhereClause, blackList?: string[]): Promise<number>
-
-        /**
-         * Create an insert statement; create more complex one with exec yourself.
-         *
-         * @param {String} table Name of the table
-         * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
-         * @param {undefined|Array} whiteList optional List of columns that only can be updated with "data"
-         * @returns {Integer} The number of inserted rows
-         */
-        insert(table: string, data: DataObject | DataObject[], whiteList?: string[]): Promise<number>
-
-        /**
-         * Create an insert statement; create more complex one with exec yourself.
-         *
-         * @param {String} table Name of the table
-         * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
-         * @param {undefined|Array} whiteBlackList optional List of columns that can not be updated with "data" (blacklist)
-         * @returns {Integer} The number of inserted rows
-         */
-        insertWithBlackList(table: string, data: DataObject | DataObject[], blackList?: string[]): Promise<number>
-
-        /**
-         * Create an replace statement; create more complex one with exec yourself.
-         *
-         * @param {String} table Name of the table
-         * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
-         * @param {undefined|Array} whiteList optional List of columns that only can be updated with "data"
-         * @returns {Integer} The number of changed rows
-         */
-        replace(table: string, data: DataObject | DataObject[], whiteList?: string[]): Promise<number>
-
-        /**
-         * Create an replace statement; create more complex one with exec yourself.
-         *
-         * @param {String} table Name of the table
-         * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
-         * @param {undefined|Array} whiteBlackList optional List of columns that can not be updated with "data" (blacklist)
-         * @returns {Integer} The number of changed rows
-         */
-        replaceWithBlackList(table: string, data: DataObject | DataObject[], blackList?: string[]): Promise<number>
-
-        /**
-         * Migrates database schema to the latest version
-         */
-        migrate(options?: MigrationOptions): Promise<void>
-    }
-
-    interface Statement {
-        bind(...params: any[]): Promise<void>
-
-        reset(): Promise<void>
-
-        finalize(): Promise<void>
-
-        run(...params: any[]): Promise<sqlite3.RunResult>
-
-        get<RowData = DataObject>(...params: any[]): Promise<RowData | undefined>
-
-        all<RowData = DataObject>(...params: any[]): Promise<RowData[]>
-
-        each<RowData = DataObject>(p1: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(p1: any, p2: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(p1: any, p2: any, p3: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, p5: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, p8: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, p8: any, p9: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, p8: any, p9: any, p10: any, callback: (row: RowData) => void): Promise<number>
-        each<RowData = DataObject>(...bindParameters: any[]): Promise<number>
-    }
-
+export type MigrationOptions = {
+    /** Whether to set to 'last' to automatically reapply the last migration-file. Default: false */
+    force?: 'last' | false
+    /** The name of the database table that is used to keep track. Default: 'migration' */
+    table?: string
+    /** The path of the migration files. Default: './migrations' */
+    migrationsPath?: string
 }
 
-import { DBOptions, DBInstance } from 'sqlite3-helper'
+export type DBOptions = {
+    /** Path to sqlite database file. Default: './data/sqlite3.db' */
+    path?: string
+    /** Whether to create a db only in memory. Default: false */
+    memory?: boolean
+    /** Whether to open database readonly. Default: false */
+    readonly?: boolean
+    /** Whether to throw error if database not exists. Default: false */
+    fileMustExist?: boolean
+    /** Whether to automatically enable 'PRAGMA journal_mode = WAL'. Default: true */
+    WAL?: boolean
+    /** Migration options. Disable completely by setting `migrate: false` */
+    migrate?: MigrationOptions | false
+}
+
+export type DataObject = { [key:string]: any }
+
+/**
+ * Specifies a where clause.
+ * 
+ *   - Either a string containing the value to use as ID that will be translated to ['id = ?', id]
+ *   - Or an array with a string and the replacements for ? after that. F.e. ['id > ? && name = ?', id, name].
+ *   - Or an object with key values. F.e. {id: params.id}. Or simply an ID that will be translated to ['id = ?', id]
+ */
+export type WhereClause = string | any[] | DataObject
+
+export interface DBInstance {
+    connection(): Promise<sqlite3.Database>
+
+    prepare(sql: string, ...params: any[]): Promise<Statement>
+
+    exec(sql: string): Promise<void>
+
+    //DB.prototype.pragma = function (source, simplify = false) {
+
+    //DB.prototype.checkpoint = function (databaseName) {
+
+    //DB.prototype.register = function (...args) {
+
+    close(): Promise<void>
+
+    //DB.prototype.defaultSafeIntegers = function (toggleState) {
+
+    /**
+     * Executes the prepared statement. When execution completes it returns an info object describing any changes made. The info object has two properties:
+     *
+     * info.changes: The total number of rows that were inserted, updated, or deleted by this operation. Changes made by foreign key actions or trigger programs do not count.
+     * info.lastInsertROWID: The rowid of the last row inserted into the database (ignoring those caused by trigger programs). If the current statement did not insert any rows into the database, this number should be completely ignored.
+     *
+     * If execution of the statement fails, an Error is thrown.
+     * @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#runbindparameters---object
+     *
+     * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
+     * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
+     * @returns {object}
+     */
+    run(query: string, ...bindParameters: any[]): Promise<sqlite3.RunResult>
+
+    /**
+     * Returns all values of a query
+     * @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#allbindparameters---array-of-rows
+     *
+     * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
+     * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
+     * @returns {array}
+     */
+    query<RowData = DataObject>(query: string, ...bindParameters: any[]): Promise<RowData[]>
+
+    /**
+     * Similar to .query(), but instead of returning every row together, an iterator is returned so you can retrieve the rows one by one.
+     * @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#iteratebindparameters---iterator
+     *
+     * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
+     * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
+     * @returns {Iterator}
+     */
+    queryIterate<RowData = DataObject>(query: string, ...bindParameters: any[]): Iterable<RowData>
+
+    /**
+     * Returns the values of the first row of the query-result
+     * @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#getbindparameters---row
+     *
+     * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
+     * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
+     * @returns {Object|null}
+     */
+    queryFirstRow<RowData = DataObject>(query: string, ...bindParameters: any[]): Promise<RowData|null>
+
+    /**
+     * Returns the values of the first row of the query-result
+     * @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#getbindparameters---row
+     * It returns always an object and thus can be used with destructuring assignment
+     *
+     * @example const {id, name} = DB().queryFirstRowObject(sql)
+     * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
+     * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
+     * @returns {Object}
+     */
+    queryFirstRowObject<RowData = DataObject>(query: string, ...bindParameters: any[]): Promise<RowData|{}>
+
+    /**
+     * Returns the value of the first column in the first row of the query-result
+     *
+     * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
+     * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
+     * @returns {any}
+     */
+    queryFirstCell<CellType = any>(query: string, ...bindParameters: any[]): Promise<CellType|undefined>
+
+    /**
+     * Calls a callback for every row
+     *
+     * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
+     * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
+     * @param {any} callback the callback that is called
+     * @returns {integer} count
+     */
+    each<RowData = DataObject>(query: string, p1: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(query: string, p1: any, p2: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, p5: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, p8: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, p8: any, p9: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(query: string, p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, p8: any, p9: any, p10: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(query: string, ...bindParameters: any[]): Promise<number>
+
+    /**
+     * Returns an Array that only contains the values of the specified column
+     *
+     * @param {Object} column Name of the column
+     * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
+     * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
+     * @returns {array}
+     */
+    queryColumn<ColumnType = any>(column: string, query: string, ...bindParameters: any[]): Promise<ColumnType[]>
+
+    /**
+     * Returns a Object that get it key-value-combination from the result of the query
+     *
+     * @param {String} key Name of the column that values should be the key
+     * @param {Object} column Name of the column that values should be the value for the object
+     * @param {Object} query the SQL-Query that should be run. Can contain placeholders for bind parameters.
+     * @param {any} bindParameters You can specify bind parameters @see https://github.com/JoshuaWise/better-sqlite3/wiki/API#binding-parameters
+     * @returns {object}
+     */
+    queryKeyAndColumn<ValueColumnType = any>(key: string, column: string, query: string, ...bindParameters: any[]): Promise<{[key:string]: ValueColumnType}>
+
+    /**
+     * Create an update statement; create more complex one with exec yourself.
+     *
+     * @param {String} table Name of the table
+     * @param {Object} data a Object of data to set. Key is the name of the column. Value 'undefined' is filtered
+     * @param {String|Array|Object} where required. array with a string and the replacements for ? after that. F.e. ['id > ? && name = ?', id, name]. Or an object with key values. F.e. {id: params.id}. Or simply an ID that will be translated to ['id = ?', id]
+     * @param {undefined|Array} whiteList optional List of columns that can only be updated with "data"
+     * @returns {Integer} The number of updated rows
+     */
+    update<RowData = DataObject>(table: string, data: Partial<RowData>, where: WhereClause, whiteList?: string[]): Promise<number>
+
+    /**
+     * Create an update statement; create more complex one with exec yourself.
+     *
+     * @param {String} table Name of the table
+     * @param {Object} data a Object of data to set. Key is the name of the column. Value 'undefined' is filtered
+     * @param {String|Array|Object} where required. array with a string and the replacements for ? after that. F.e. ['id > ? && name = ?', id, name]. Or an object with key values. F.e. {id: params.id}. Or simply an ID that will be translated to ['id = ?', id]
+     * @param {undefined|Array} whiteBlackList optional List of columns that can not be updated with "data" (blacklist)
+     * @returns {Integer} The number of updated rows
+     */
+    updateWithBlackList(table: string, data: DataObject, where: WhereClause, blackList?: string[]): Promise<number>
+
+    /**
+     * Create an insert statement; create more complex one with exec yourself.
+     *
+     * @param {String} table Name of the table
+     * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
+     * @param {undefined|Array} whiteList optional List of columns that only can be updated with "data"
+     * @returns {Integer} The number of inserted rows
+     */
+    insert(table: string, data: DataObject | DataObject[], whiteList?: string[]): Promise<number>
+
+    /**
+     * Create an insert statement; create more complex one with exec yourself.
+     *
+     * @param {String} table Name of the table
+     * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
+     * @param {undefined|Array} whiteBlackList optional List of columns that can not be updated with "data" (blacklist)
+     * @returns {Integer} The number of inserted rows
+     */
+    insertWithBlackList(table: string, data: DataObject | DataObject[], blackList?: string[]): Promise<number>
+
+    /**
+     * Create an replace statement; create more complex one with exec yourself.
+     *
+     * @param {String} table Name of the table
+     * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
+     * @param {undefined|Array} whiteList optional List of columns that only can be updated with "data"
+     * @returns {Integer} The number of changed rows
+     */
+    replace(table: string, data: DataObject | DataObject[], whiteList?: string[]): Promise<number>
+
+    /**
+     * Create an replace statement; create more complex one with exec yourself.
+     *
+     * @param {String} table Name of the table
+     * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
+     * @param {undefined|Array} whiteBlackList optional List of columns that can not be updated with "data" (blacklist)
+     * @returns {Integer} The number of changed rows
+     */
+    replaceWithBlackList(table: string, data: DataObject | DataObject[], blackList?: string[]): Promise<number>
+
+    /**
+     * Migrates database schema to the latest version
+     */
+    migrate(options?: MigrationOptions): Promise<void>
+}
+
+interface Statement {
+    bind(...params: any[]): Promise<void>
+
+    reset(): Promise<void>
+
+    finalize(): Promise<void>
+
+    run(...params: any[]): Promise<sqlite3.RunResult>
+
+    get<RowData = DataObject>(...params: any[]): Promise<RowData | undefined>
+
+    all<RowData = DataObject>(...params: any[]): Promise<RowData[]>
+
+    each<RowData = DataObject>(p1: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(p1: any, p2: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(p1: any, p2: any, p3: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, p5: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, p8: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, p8: any, p9: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(p1: any, p2: any, p3: any, p4: any, p5: any, p6: any, p7: any, p8: any, p9: any, p10: any, callback: (row: RowData) => void): Promise<number>
+    each<RowData = DataObject>(...bindParameters: any[]): Promise<number>
+}
 
 export default function DB(options?: DBOptions): DBInstance

--- a/no-generators.d.ts
+++ b/no-generators.d.ts
@@ -187,7 +187,7 @@ export interface DBInstance {
      * @param {String} table Name of the table
      * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
      * @param {undefined|Array} whiteList optional List of columns that only can be updated with "data"
-     * @returns {Integer} The number of inserted rows
+     * @returns {Integer} The ID of the last inserted row
      */
     insert(table: string, data: DataObject | DataObject[], whiteList?: string[]): Promise<number>
 
@@ -197,7 +197,7 @@ export interface DBInstance {
      * @param {String} table Name of the table
      * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
      * @param {undefined|Array} whiteBlackList optional List of columns that can not be updated with "data" (blacklist)
-     * @returns {Integer} The number of inserted rows
+     * @returns {Integer} The ID of the last inserted row
      */
     insertWithBlackList(table: string, data: DataObject | DataObject[], blackList?: string[]): Promise<number>
 
@@ -207,7 +207,7 @@ export interface DBInstance {
      * @param {String} table Name of the table
      * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
      * @param {undefined|Array} whiteList optional List of columns that only can be updated with "data"
-     * @returns {Integer} The number of changed rows
+     * @returns {Integer} The ID of the last replaced row
      */
     replace(table: string, data: DataObject | DataObject[], whiteList?: string[]): Promise<number>
 
@@ -217,7 +217,7 @@ export interface DBInstance {
      * @param {String} table Name of the table
      * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
      * @param {undefined|Array} whiteBlackList optional List of columns that can not be updated with "data" (blacklist)
-     * @returns {Integer} The number of changed rows
+     * @returns {Integer} The ID of the last replaced row
      */
     replaceWithBlackList(table: string, data: DataObject | DataObject[], blackList?: string[]): Promise<number>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,21 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@types/node": {
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.2.tgz",
+      "integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
+      "dev": true
+    },
+    "@types/sqlite3": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sqlite3/-/sqlite3-3.1.5.tgz",
+      "integrity": "sha512-upsrd1zEYMa4Y+prurQ+vpo5SN63BUF6tOjeTv3ziF+9W9PHVh4/S5cy0qAqkHvmOEm/AZhEKd7V/0bR2udmFw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "sqlite3": "^4.1.0"
   },
   "devDependencies": {
+    "@types/sqlite3": "^3.1.5",
     "chai": "^4.2.0",
     "eslint": "^6.2.0",
     "eslint-config-standard": "^14.0.0",

--- a/src/database.js
+++ b/src/database.js
@@ -44,7 +44,10 @@ DB.prototype.connection = async function () {
       mkdirp.sync(path.dirname(this.options.path))
     }
     this.db = await new Promise((resolve, reject) => {
-      const db = new sqlite3.Database(this.options.memory ? ':memory:' : this.options.path, (err) => err ? reject(err) : resolve(db))
+      const db = new sqlite3.Database(
+        this.options.memory ? ':memory:' : this.options.path,
+        this.options.readonly ? sqlite3.OPEN_READONLY : sqlite3.OPEN_READWRITE,
+        (err) => err ? reject(err) : resolve(db))
     })
 
     if (this.options.WAL) {

--- a/src/database.js
+++ b/src/database.js
@@ -343,7 +343,7 @@ DB.prototype.updateWithBlackList = async function (table, data, where, blackList
  * @param {String} table Name of the table
  * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
  * @param {undefined|Array} whiteList optional List of columns that only can be updated with "data"
- * @returns {Integer}
+ * @returns {Integer} The ID of the last inserted row
  */
 DB.prototype.insert = async function (table, data, whiteList) {
   return (await this.run(
@@ -357,7 +357,7 @@ DB.prototype.insert = async function (table, data, whiteList) {
  * @param {String} table Name of the table
  * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
  * @param {undefined|Array} whiteBlackList optional List of columns that can not be updated with "data" (blacklist)
- * @returns {Integer}
+ * @returns {Integer} The ID of the last inserted row
  */
 DB.prototype.insertWithBlackList = async function (table, data, blackList) {
   return this.insert(table, data, await createWhiteListByBlackList.bind(this)(table, blackList))
@@ -369,7 +369,7 @@ DB.prototype.insertWithBlackList = async function (table, data, blackList) {
  * @param {String} table Name of the table
  * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
  * @param {undefined|Array} whiteList optional List of columns that only can be updated with "data"
- * @returns {Integer}
+ * @returns {Integer} The ID of the last replaced row
  */
 DB.prototype.replace = async function (table, data, whiteList) {
   return (await this.run(
@@ -383,7 +383,7 @@ DB.prototype.replace = async function (table, data, whiteList) {
  * @param {String} table Name of the table
  * @param {Object|Array} data a Object of data to set. Key is the name of the column. Can be an array of objects.
  * @param {undefined|Array} whiteBlackList optional List of columns that can not be updated with "data" (blacklist)
- * @returns {Integer}
+ * @returns {Integer} The ID of the last replaced row
  */
 DB.prototype.replaceWithBlackList = async function (table, data, blackList) {
   return this.replace(table, data, await createWhiteListByBlackList.bind(this)(table, blackList))

--- a/src/database.js
+++ b/src/database.js
@@ -36,13 +36,15 @@ DB.prototype.connection = async function () {
     return this.db
   }
   try {
-    if (this.options.fileMustExist && !fs.existsSync(this.options.path)) {
-      throw new Error("DB file doesn't exist: " + path.resolve(this.options.path))
+    if (!this.options.memory) {
+      if (this.options.fileMustExist && !fs.existsSync(this.options.path)) {
+        throw new Error("DB file doesn't exist: " + path.resolve(this.options.path))
+      }
+      // create path if it doesn't exists
+      mkdirp.sync(path.dirname(this.options.path))
     }
-    // create path if it doesn't exists
-    mkdirp.sync(path.dirname(this.options.path))
     this.db = await new Promise((resolve, reject) => {
-      const db = new sqlite3.Database(this.options.path, (err) => err ? reject(err) : resolve(db))
+      const db = new sqlite3.Database(this.options.memory ? ':memory:' : this.options.path, (err) => err ? reject(err) : resolve(db))
     })
   } catch (e) {
     this.db = undefined

--- a/src/database.js
+++ b/src/database.js
@@ -428,6 +428,12 @@ function createInsertOrReplaceStatement (insertOrReplace, table, data, whiteList
  * Migrates database schema to the latest version
  */
 DB.prototype.migrate = async function ({ force, table = 'migrations', migrationsPath = './migrations' } = {}) {
+  if (!this.options.migrate) {
+    // We don't call `connection` if `options.migrate` is `true`, because in this case `connection` will call `migrate`
+    // which would lead into a dead-lock.
+    await this.connection()
+  }
+
   const exec = (query, ...bindParameters) => new Promise((resolve, reject) => this.db.exec(query, ...bindParameters, err => err ? reject(err) : resolve()))
   const run = (query, ...bindParameters) => new Promise((resolve, reject) => this.db.run(query, ...bindParameters, function (err) { err ? reject(err) : resolve(this) }))
   const query = (query, ...bindParameters) => new Promise((resolve, reject) => this.db.all(query, ...bindParameters, (err, rows) => err ? reject(err) : resolve(rows)))

--- a/src/database.js
+++ b/src/database.js
@@ -36,6 +36,9 @@ DB.prototype.connection = async function () {
     return this.db
   }
   try {
+    if (this.options.fileMustExist && !fs.existsSync(this.options.path)) {
+      throw new Error("DB file doesn't exist: " + path.resolve(this.options.path))
+    }
     // create path if it doesn't exists
     mkdirp.sync(path.dirname(this.options.path))
     this.db = await new Promise((resolve, reject) => {


### PR DESCRIPTION
I fixed some stuff:

- TypeScript definitions didn't work in some environments
- Option `fileMustExist` wasn't implemented
- Option `memory` wasn't implemented
- awaitLock wasn't released in all cases
- Option `readonly` wasn't implemented
- `migrate` didn't work without calling `connection` before
- documentation fix: insert* and replace* returns lastId