### PR TITLE
Add typing for using `DB` as a constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ const DB = require('sqlite3-helper');
 })()
 ```
 
+## Multiple instances
+If you need access to more than one database, you can use `DB` as a constructor (calling `new DB(...)` instead of just `DB(...)`):
+
+```js
+const DB = require('sqlite3-helper');
+
+const db1 = new DB({ path: './data/first-db.sqlite' })
+const db2 = new DB({ path: './data/second-db.sqlite' })
+
+(async ()=>{
+  let row = await db1.queryFirstRow('SELECT * FROM users WHERE id=?', userId);
+  console.log(row.firstName, row.lastName, row.email);
+})()
+```
+
 ## New Functions
 This class implements shorthand methods for [sqlite3](https://www.npmjs.com/package/sqlite3).
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,4 +23,5 @@ export interface Statement extends noGenerators.Statement {
     iterate<RowData = DataObject>(...bindParameters: any[]): Iterable<RowData>
 }
 
-export default function DB(options?: DBOptions): DBInstance
+declare const DB: { new(options?: DBOptions): DBInstance } & ((options?: DBOptions) => DBInstance)
+export default DB

--- a/no-generators.d.ts
+++ b/no-generators.d.ts
@@ -253,4 +253,5 @@ interface Statement {
     each<RowData = DataObject>(...bindParameters: any[]): Promise<number>
 }
 
-export default function DB(options?: DBOptions): DBInstance
+declare const DB: { new(options?: DBOptions): DBInstance } & ((options?: DBOptions) => DBInstance)
+export default DB


### PR DESCRIPTION
I added typing for using `DB` as a constructor (for accessing multiple databases).